### PR TITLE
Add Docker Support for scgpt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use the specified base image
+FROM pytorch/pytorch:1.13.0-cuda11.6-cudnn8-devel
+
+# Set environment variable to prevent interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update the package list
+RUN apt-get update -y
+
+# Install git
+RUN apt-get install -y git
+
+# Install r-base and tzdata
+RUN apt-get install -y r-base tzdata
+
+# Install Python packages using pip
+RUN pip install packaging
+RUN pip install scgpt "flash-attn<1.0.5"
+RUN pip install markupsafe==2.0.1
+RUN pip install wandb

--- a/README.md
+++ b/README.md
@@ -46,6 +46,37 @@ $ poetry install
 
 **Note**: The `flash-attn` dependency usually requires specific GPU and CUDA version. If you encounter any issues, please refer to the [flash-attn](https://github.com/HazyResearch/flash-attention/tree/main) repository for installation instructions. For now, May 2023, we recommend using CUDA 11.7 and flash-attn<1.0.5 due to various issues reported about installing new versions of flash-attn.
 
+## Using the Docker Image for scGPT
+
+By using the `scGPT Docker image`, you can bypass the complexities of manual package installation, ensuring a consistent deployment environment. Included in this repository is a Dockerfile that lets you craft a container for the project; you have the choice to either build this image on your own or conveniently pull it from Docker Hub.
+
+### Building the Docker Image
+
+To build the Docker image from the provided `Dockerfile`, run the following command from the root directory of this repository:
+
+```bash
+docker build -t scgpt:latest -f Dockerfile .
+```
+
+### Pulling the Docker Image from Docker Hub
+
+If you don't want to build the image yourself, you can pull it directly from Docker Hub:
+
+```bash
+docker pull xueerchen/scgpt:0.1.7
+docker tag xueerchen/scgpt:0.1.7 scgpt:latest
+```
+
+### Running the Docker Container
+
+Once you have the image (either by building it or pulling it), you can start a container with:
+
+```bash
+docker run --gpus all --rm -it scgpt:latest bash
+```
+
+Please note: When running the Docker container, ensure you mount any necessary folders using the -v option to access them inside the container.
+
 ## Pretrained scGPT Model Zoo
 
 Here is the list of pretrained models. Please find the links for downloading the checkpoint folders. We recommend using the `whole-human` model for most applications by default. If your fine-tuning dataset shares similar cell type context with the training data of the organ-specific models, these models can usually demonstrate competitive performance as well.


### PR DESCRIPTION
Hello,

I've noticed that the `scGPT` project could benefit from Docker to streamline setup and ensure consistent environments. This pull request introduces a `Dockerfile` to facilitate this.

**Changes Made:**
- Added a `Dockerfile` to allow users to create a Docker container for the project.
- Updated `README.md` with instructions on how to build the Docker image or pull it from Docker Hub, and run it. 

I believe this addition will make the project more accessible to users unfamiliar with its dependencies and setup. It also provides an easy way for anyone to run the project in an isolated environment, avoiding potential conflicts with other installed software.

Please review the changes, and let me know if any modifications are needed. Looking forward to your feedback!

Best regards,
xueer