### PR TITLE
improve flash-attn error message

### DIFF
--- a/scgpt/model/model.py
+++ b/scgpt/model/model.py
@@ -75,7 +75,7 @@ class TransformerModel(nn.Module):
         if use_fast_transformer:
             if not flash_attn_available:
                 warnings.warn(
-                    "flash-attn is not installed, using pytorch transformer instead. "
+                    "a compatible version of flash-attn is not installed, using pytorch transformer instead. "
                     "Set use_fast_transformer=False to avoid this warning. "
                     "Installing flash-attn is highly recommended."
                 )


### PR DESCRIPTION
Updating error message from "flash-attn is not installed" to "a compatible version of flash-attn is not installed," since the former error message is confusing to those who actually do have flash-attn installed, just a more recent version (not <1.0.5) in which flash_attn.flash_attention.FlashMHA is no longer included