### PR TITLE
fix a depreciated .A issue from newer versions of scipy

### DIFF
--- a/scgpt/preprocess.py
+++ b/scgpt/preprocess.py
@@ -179,7 +179,7 @@ class Preprocessor:
             binned_rows = []
             bin_edges = []
             layer_data = _get_obs_rep(adata, layer=key_to_process)
-            layer_data = layer_data.A if issparse(layer_data) else layer_data
+            layer_data = layer_data.toarray() if issparse(layer_data) else layer_data
             if layer_data.min() < 0:
                 raise ValueError(
                     f"Assuming non-negative data, but got min value {layer_data.min()}."


### PR DESCRIPTION
The csr_matrix.A has been depreciated in newer scipy. See https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.sparse.csr_matrix.A.html